### PR TITLE
Revert "Define an Alternative instance for Freer."

### DIFF
--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -10,7 +10,6 @@ module Control.Monad.Free.Freer
 , wrap
 ) where
 
-import Control.Applicative
 import Control.Monad ((>=>))
 import Control.Monad.Free.Class hiding (liftF)
 import qualified Control.Monad.Trans.Free.Freer as T
@@ -66,10 +65,6 @@ instance Applicative (Freer f) where
   g <*> a = case g of
     Return f -> fmap f a
     Then r t -> Then r ((<*> a) . t)
-
-instance Alternative f => Alternative (Freer f) where
-  empty = wrap empty
-  a <|> b = wrap (pure a <|> pure b)
 
 instance Monad (Freer f) where
   return = pure


### PR DESCRIPTION
Reverts robrix/freer-cofreer#3.

This impairs our ability to construct correct specialized `Alternative` instances as the parameter type may not have a `Functor` instance (required by `Applicative`, in turn required by `Alternative`).