### PR TITLE
Benchmark retract

### DIFF
--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = pure ()

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,2 +1,27 @@
+{-# LANGUAGE GADTs #-}
+import Control.Monad.Free.Freer
+import Criterion.Main
+import Prelude hiding (read)
+
 main :: IO ()
-main = pure ()
+main = defaultMain
+  [ bgroup "retract" (b retract <$> [30])
+  , bgroup "retract2" (b retract' <$> [30])
+  ]
+  where b f i = bench (show i) (whnf (f . program) i)
+
+retract' :: Monad m => Freer m a -> m a
+retract' (Return a) = return a
+retract' (action `Then` yield) = action >>= retract' . yield
+{-# INLINE retract' #-}
+
+program :: Int -> Freer (Either String) Int
+program n
+  | n < 0 = (Left "negative") `Then` return
+  | otherwise = go n
+  where go 0 = return 0
+        go 1 = Right 1 `Then` return
+        go n = do
+          x <- go (pred n)
+          y <- go (pred (pred n))
+          Right (x + y) `Then` return

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,22 +1,64 @@
-{-# LANGUAGE GADTs #-}
-import Control.Monad.Free.Freer
+{-# LANGUAGE RankNTypes #-}
+import Control.Monad.Free.Freer hiding (retract, iterFreer, iterFreerA)
 import Criterion.Main
+import Data.Functor.Foldable
 import Prelude hiding (read)
 
 main :: IO ()
 main = defaultMain
-  [ bgroup "retract" (b retract <$> [30])
-  , bgroup "retract2" (b retract' <$> [30])
+  [ bgroup "retract"
+    [ bgroup "iteration-catamorphism" (b retract <$> [30])
+    , bgroup "iteration-recursion" (b retract' <$> [30])
+    , bgroup "direct-recursion" (b retract'' <$> [30])
+    ]
   ]
-  where b f i = bench (show i) (whnf (f . program) i)
+  where b f i = bench (show i) (whnf (f . fib) i)
+
+-- iteration-catamorphism
+
+retract :: Monad m => Freer m a -> m a
+retract = iterFreerA (>>=)
+{-# INLINE retract #-}
+
+iterFreer :: (forall x. f x -> (x -> a) -> a) -> Freer f a -> a
+iterFreer algebra = cata $ \ r -> case r of
+  ReturnF result -> result
+  ThenF action continue -> algebra action continue
+{-# INLINE iterFreer #-}
+
+iterFreerA :: Applicative m => (forall x. f x -> (x -> m a) -> m a) -> Freer f a -> m a
+iterFreerA algebra r = iterFreer algebra (fmap pure r)
+{-# INLINE iterFreerA #-}
+
+
+-- iteration-recursion
 
 retract' :: Monad m => Freer m a -> m a
-retract' (Return a) = return a
-retract' (action `Then` yield) = action >>= retract' . yield
+retract' = iterFreerA' (>>=)
 {-# INLINE retract' #-}
 
-program :: Int -> Freer (Either String) Int
-program n
+iterFreer' :: (forall x. f x -> (x -> a) -> a) -> Freer f a -> a
+iterFreer' algebra = go
+  where go (Return result) = result
+        go (Then action continue) = algebra action (go . continue)
+        {-# INLINE go #-}
+{-# INLINE iterFreer' #-}
+
+iterFreerA' :: Applicative m => (forall x. f x -> (x -> m a) -> m a) -> Freer f a -> m a
+iterFreerA' algebra r = iterFreer' algebra (fmap pure r)
+{-# INLINE iterFreerA' #-}
+
+
+-- direct-recursion
+
+retract'' :: Monad m => Freer m a -> m a
+retract'' (Return a) = return a
+retract'' (action `Then` yield) = action >>= retract' . yield
+{-# INLINE retract'' #-}
+
+
+fib :: Int -> Freer (Either String) Int
+fib n
   | n < 0 = (Left "negative") `Then` return
   | otherwise = go n
   where go 0 = return 0

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,2 @@
+packages: freer-cofreer.cabal
 jobs: $ncpus

--- a/freer-cofreer.cabal
+++ b/freer-cofreer.cabal
@@ -49,6 +49,7 @@ benchmark benchmark
   build-depends:       base
                      , criterion
                      , freer-cofreer
+                     , recursion-schemes
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -O2
   default-language:    Haskell2010
 

--- a/freer-cofreer.cabal
+++ b/freer-cofreer.cabal
@@ -47,6 +47,7 @@ benchmark benchmark
   hs-source-dirs:      benchmark
   main-is:             Bench.hs
   build-depends:       base
+                     , criterion
                      , freer-cofreer
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -O2
   default-language:    Haskell2010

--- a/freer-cofreer.cabal
+++ b/freer-cofreer.cabal
@@ -42,6 +42,15 @@ test-suite test
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 
+benchmark benchmark
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      benchmark
+  main-is:             Bench.hs
+  build-depends:       base
+                     , freer-cofreer
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -O2
+  default-language:    Haskell2010
+
 source-repository head
   type:     git
   location: https://github.com/robrix/freer-cofreer

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -40,6 +40,8 @@ hoistFreer :: (forall a. f a -> g a) -> Freer f b -> Freer g b
 hoistFreer f = go
   where go (Return result) = Return result
         go (Then step yield) = Then (f step) (go . yield)
+        {-# INLINE go #-}
+{-# INLINE hoistFreer #-}
 
 
 data FreerF f a b where

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -101,9 +101,8 @@ stepFreer :: (forall x. f x -> Freer f x)
           -> Freer f result
           -> Either result (Freer f result)
 stepFreer refine = go
-  where go r = case r of
-          Return a -> Left a
-          step `Then` yield -> Right (refine step >>= yield)
+  where go (Return a) = Left a
+        go (step `Then` yield) = Right (refine step >>= yield)
 
 -- | Run a program to completion by repeated refinement, returning the list of steps up to and including the final result.
 --

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -228,10 +228,9 @@ instance Traversable f => Traversable (FreerF f a) where
 
 
 instance Eq1 f => Eq2 (FreerF f) where
-  liftEq2 eqA eqB f1 f2 = case (f1, f2) of
-    (ReturnF a1, ReturnF a2) -> eqA a1 a2
-    (ThenF r1 t1, ThenF r2 t2) -> liftEq (\ x1 x2 -> eqB (t1 x1) (t2 x2)) r1 r2
-    _ -> False
+  liftEq2 eqResult eqRecur (ReturnF result1) (ReturnF result2) = eqResult result1 result2
+  liftEq2 _ eqRecur (ThenF step1 yield1) (ThenF step2 yield2) = liftEq (\ x1 x2 -> eqRecur (yield1 x1) (yield2 x2)) step1 step2
+  liftEq2 _ _ _ _ = False
 
 instance (Eq1 f, Eq a) => Eq1 (FreerF f a) where
   liftEq = liftEq2 (==)

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -243,9 +243,8 @@ instance (Eq1 f, Eq a, Eq b) => Eq (FreerF f a b) where
 
 
 instance Show1 f => Show2 (FreerF f) where
-  liftShowsPrec2 sp1 _ sp2 sa2 d f = case f of
-    ReturnF a -> showsUnaryWith sp1 "ReturnF" d a
-    ThenF r t -> showsBinaryWith (liftShowsPrec (\ i -> sp2 i . t) (sa2 . fmap t)) (const showString) "ThenF" d r "_"
+  liftShowsPrec2 sp1 _ _ _ d (ReturnF result) = showsUnaryWith sp1 "ReturnF" d result
+  liftShowsPrec2 sp1 _ sp2 sa2 d (ThenF step yield) = showsBinaryWith (liftShowsPrec ((. yield) . sp2) (sa2 . fmap yield)) (const showString) "ThenF" d step "_"
 
 instance (Show1 f, Show a) => Show1 (FreerF f a) where
   liftShowsPrec = liftShowsPrec2 showsPrec showList

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -196,11 +196,10 @@ instance (Show1 f, Show a) => Show (Freer f a) where
   showsPrec = liftShowsPrec showsPrec showList
 
 instance Eq1 f => Eq1 (Freer f) where
-  liftEq eqA = go
-    where go r s = case (r, s) of
-            (Return a1, Return a2) -> eqA a1 a2
-            (Then r1 t1, Then r2 t2) -> liftEq (\ x1 x2 -> go (t1 x1) (t2 x2)) r1 r2
-            _ -> False
+  liftEq eqResult = go
+    where go (Return result1) (Return result2) = eqResult result1 result2
+          go (Then step1 yield1) (Then step2 yield2) = liftEq (\ x1 x2 -> go (yield1 x1) (yield2 x2)) step1 step2
+          go _ _ = False
 
 instance (Eq1 f, Eq a) => Eq (Freer f a) where
   (==) = liftEq (==)

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -38,9 +38,8 @@ liftF action = action `Then` return
 
 hoistFreer :: (forall a. f a -> g a) -> Freer f b -> Freer g b
 hoistFreer f = go
-  where go r = case r of
-          Return a -> Return a
-          Then r t -> Then (f r) (go . t)
+  where go (Return result) = Return result
+        go (Then step yield) = Then (f step) (go . yield)
 
 
 data FreerF f a b where

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -83,6 +83,7 @@ runFreer :: forall f result
 runFreer refine = go
   where go :: Freer f x -> x
         go = iterFreer (flip ($) . go . refine)
+        {-# INLINE go #-}
 {-# INLINE runFreer #-}
 
 -- | Run a program to completion by repeated refinement in some 'Monad'ic context, and return its result.

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -64,9 +64,10 @@ iterA :: (Functor f, Applicative m) => (f (m a) -> m a) -> Freer f a -> m a
 iterA algebra = iterFreerA ((algebra .) . flip fmap)
 
 iterFreer :: (forall x. f x -> (x -> a) -> a) -> Freer f a -> a
-iterFreer algebra = cata $ \ r -> case r of
-  ReturnF result -> result
-  ThenF action continue -> algebra action continue
+iterFreer algebra = go
+  where go (Return result) = result
+        go (Then action continue) = algebra action (go . continue)
+        {-# INLINE go #-}
 {-# INLINE iterFreer #-}
 
 iterFreerA :: Applicative m => (forall x. f x -> (x -> m a) -> m a) -> Freer f a -> m a

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -218,9 +218,8 @@ instance Bifunctor (FreerF f) where
 
 
 instance Foldable f => Foldable (FreerF f a) where
-  foldMap f g = case g of
-    ReturnF _ -> mempty
-    ThenF r t -> foldMap (f . t) r
+  foldMap _ (ReturnF _) = mempty
+  foldMap f (ThenF step yield) = foldMap (f . yield) step
   {-# INLINE foldMap #-}
 
 instance Traversable f => Traversable (FreerF f a) where

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -137,9 +137,8 @@ cutoff _ r = Right <$> r
 
 instance Functor (Freer f) where
   fmap f = go
-    where go r = case r of
-            Return a -> Return (f a)
-            Then r t -> Then r (go . t)
+    where go (Return result) = Return (f result)
+          go (Then step yield) = Then step (go . yield)
   {-# INLINE fmap #-}
 
 instance Applicative (Freer f) where

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -139,6 +139,7 @@ instance Functor (Freer f) where
   fmap f = go
     where go (Return result) = Return (f result)
           go (Then step yield) = Then step (go . yield)
+          {-# INLINE go #-}
   {-# INLINE fmap #-}
 
 instance Applicative (Freer f) where

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -128,8 +128,9 @@ foldFreer f = retract . hoistFreer f
 
 cutoff :: Integer -> Freer f a -> Freer f (Either (Freer f a) a)
 cutoff n r | n <= 0 = return (Left r)
-cutoff n (Then a f) = Then a (cutoff (pred n) . f)
+cutoff n (Then step yield) = Then step (cutoff (pred n) . yield)
 cutoff _ r = Right <$> r
+{-# INLINE cutoff #-}
 
 
 -- Instances

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -51,9 +51,8 @@ liftFreerF action = action `ThenF` id
 {-# INLINE liftFreerF #-}
 
 hoistFreerF :: (forall a. f a -> g a) -> FreerF f b c -> FreerF g b c
-hoistFreerF f r = case r of
-  ReturnF a -> ReturnF a
-  ThenF r t -> ThenF (f r) t
+hoistFreerF _ (ReturnF result) = ReturnF result
+hoistFreerF f (ThenF step yield) = ThenF (f step) yield
 
 
 iter :: Functor f => (f a -> a) -> Freer f a -> a

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -189,9 +189,8 @@ instance Traversable f => Traversable (Freer f) where
 
 instance Show1 f => Show1 (Freer f) where
   liftShowsPrec sp sl = go
-    where go d r = case r of
-            Return a -> showsUnaryWith sp "Return" d a
-            Then r t -> showsBinaryWith (liftShowsPrec ((. t) . go) (liftShowList sp sl . fmap t)) (const showString) "Then" d r "_"
+    where go d (Return a) = showsUnaryWith sp "Return" d a
+          go d (Then step yield) = showsBinaryWith (liftShowsPrec ((. yield) . go) (liftShowList sp sl . fmap yield)) (const showString) "Then" d step "_"
 
 instance (Show1 f, Show a) => Show (Freer f a) where
   showsPrec = liftShowsPrec showsPrec showList

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -212,9 +212,8 @@ instance Functor (FreerF f a) where
   {-# INLINE fmap #-}
 
 instance Bifunctor (FreerF f) where
-  bimap f g r = case r of
-    ReturnF a -> ReturnF (f a)
-    ThenF r t -> ThenF r (g . t)
+  bimap f _ (ReturnF result) = ReturnF (f result)
+  bimap _ g (ThenF step yield) = ThenF step (g . yield)
   {-# INLINE bimap #-}
 
 

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -223,9 +223,8 @@ instance Foldable f => Foldable (FreerF f a) where
   {-# INLINE foldMap #-}
 
 instance Traversable f => Traversable (FreerF f a) where
-  traverse f g = case g of
-    ReturnF a -> pure (ReturnF a)
-    ThenF r t -> liftFreerF <$> traverse (f . t) r
+  traverse _ (ReturnF result) = pure (ReturnF result)
+  traverse f (ThenF step yield) = liftFreerF <$> traverse (f . yield) step
   {-# INLINE traverse #-}
 
 


### PR DESCRIPTION
This PR benchmarks three different approaches to `retract`, and based on the results, redefines `iterFreer` with direct recursion.