### PR TITLE
Yield first

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ greeting = do
   write "Hi! What’s your name?\n"
   name <- read
   write $ "Pleased to meet you, " ++ name ++ "!"
+
+runPrompt :: Prompt a -> IO a
+runPrompt = iterFreer (\ yield instruction -> case instruction of
+  Write s -> putStrLn >>= yield
+  Read -> getLine >>= yield)
 ```
 
 The constraints placed on the constructors of `PromptF` mean that it doesn’t admit a `Functor` instance, and thus is not very useful with `Free`. With `Freer`, you get `Functor`, `Applicative`, and `Monad` instances with `PromptF` “for free,” complete with the majority of the API defined in `Control.Monad.Free.Freer`.

--- a/README.md
+++ b/README.md
@@ -5,25 +5,25 @@ This is an implementation of the Freer monad described by Oleg Kiselykov in _[Fr
 `Freer` and `Cofreer` differentiate themselves from `Free` and `Cofree` by admitting `Functor` & `Monad`/`Comonad` instances even when the signature is not a `Functor`. This makes them particularly suitable for working with certain GADTs. For example:
 
 ```Haskell
-data OpF a where
-  Write :: String -> OpF ()
-  Read :: OpF String
+data PromptF a where
+  Write :: String -> PromptF ()
+  Read :: PromptF String
 
-type Op = Freer OpF
+type Prompt = Freer PromptF
 
-write :: String -> Op ()
+write :: String -> Prompt ()
 write s = Write s `Then` Return
 
-read :: Op String
+read :: Prompt String
 read = Read `Then` Return
 
-greeting :: Op ()
+greeting :: Prompt ()
 greeting = do
   write "Hi! What’s your name?\n"
   name <- read
   write $ "Pleased to meet you, " ++ name ++ "!"
 ```
 
-The constraints placed on the constructors of `OpF` mean that it doesn’t admit a `Functor` instance, and thus is not very useful with `Free`. With `Freer`, you get `Functor`, `Applicative`, and `Monad` instances with `OpF` “for free,” complete with the majority of the API defined in `Control.Monad.Free.Freer`.
+The constraints placed on the constructors of `PromptF` mean that it doesn’t admit a `Functor` instance, and thus is not very useful with `Free`. With `Freer`, you get `Functor`, `Applicative`, and `Monad` instances with `PromptF` “for free,” complete with the majority of the API defined in `Control.Monad.Free.Freer`.
 
 [Free and Freer]: http://okmij.org/ftp/Computation/free-monad.html

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -58,10 +58,10 @@ hoistFreerF f (ThenF step yield) = ThenF (f step) yield
 
 
 iter :: Functor f => (f a -> a) -> Freer f a -> a
-iter algebra = iterFreer (fmap algebra . fmap)
+iter algebra = iterFreer (\ yield -> algebra . fmap yield)
 
 iterA :: (Functor f, Applicative m) => (f (m a) -> m a) -> Freer f a -> m a
-iterA algebra = iterFreerA (fmap algebra . fmap)
+iterA algebra = iterFreerA (\ yield -> algebra . fmap yield)
 
 iterFreer :: (forall x. (x -> a) -> f x -> a) -> Freer f a -> a
 iterFreer algebra = go

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -57,6 +57,9 @@ hoistFreerF _ (ReturnF result) = ReturnF result
 hoistFreerF f (ThenF step yield) = ThenF (f step) yield
 
 
+-- | Tear down a 'Freer' 'Monad' using iteration.
+--
+--   This is analogous to 'cata' where the 'Return'ed values are placeholders for the result of the computation.
 iter :: Functor f => (f a -> a) -> Freer f a -> a
 iter algebra = iterFreer (\ yield -> algebra . fmap yield)
 

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -79,6 +79,9 @@ iterFreer algebra = go
         {-# INLINE go #-}
 {-# INLINE iterFreer #-}
 
+-- | Tear down a 'Freer' 'Monad' using iteration with an explicit continuation in some 'Applicative' context.
+--
+--   This is analogous to 'iterA' with a continuation for the interior values, and is therefore suitable for defining interpreters for GADTs/types lacking a 'Functor' instance.
 iterFreerA :: Applicative m => (forall x. (x -> m a) -> f x -> m a) -> Freer f a -> m a
 iterFreerA algebra r = iterFreer algebra (fmap pure r)
 {-# INLINE iterFreerA #-}

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -63,6 +63,9 @@ hoistFreerF f (ThenF step yield) = ThenF (f step) yield
 iter :: Functor f => (f a -> a) -> Freer f a -> a
 iter algebra = iterFreer (\ yield -> algebra . fmap yield)
 
+-- | Tear down a 'Freer' 'Monad' using iteration in some 'Applicative' context.
+--
+--   This is analogous to 'cata' where the 'Return'ed values are placeholders for the result of the computation.
 iterA :: (Functor f, Applicative m) => (f (m a) -> m a) -> Freer f a -> m a
 iterA algebra = iterFreerA (\ yield -> algebra . fmap yield)
 

--- a/src/Control/Monad/Free/Freer.hs
+++ b/src/Control/Monad/Free/Freer.hs
@@ -69,6 +69,9 @@ iter algebra = iterFreer (\ yield -> algebra . fmap yield)
 iterA :: (Functor f, Applicative m) => (f (m a) -> m a) -> Freer f a -> m a
 iterA algebra = iterFreerA (\ yield -> algebra . fmap yield)
 
+-- | Tear down a 'Freer' 'Monad' using iteration with an explicit continuation.
+--
+--   This is analogous to 'iter' with a continuation for the interior values, and is therefore suitable for defining interpreters for GADTs/types lacking a 'Functor' instance.
 iterFreer :: (forall x. (x -> a) -> f x -> a) -> Freer f a -> a
 iterFreer algebra = go
   where go (Return result) = result


### PR DESCRIPTION
This PR makes `iterFreer`’s algebra take the continuation as the first argument, which makes it conveniently symmetrical and easier to understand in relation to open recursion in general.