### PR TITLE
Ignore stack-work-profiling directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cabal.project.local
 dist-newstyle
 .stack-work
+.stack-work-profiling


### PR DESCRIPTION
Since we're using the `--workdir` trick for stack builds, we want to make sure this directory is ignored when we vend our dependencies directly.